### PR TITLE
Fix: Older ReactJS is no longer available

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 	<title>Simple Image Gallery</title>
-	<script src="http://fb.me/react-with-addons-0.8.0.js"></script>
-	<script src="http://fb.me/JSXTransformer-0.8.0.js"></script>
+	<script src="https://fb.me/react-with-addons-0.13.3.js"></script>
+	<script src="https://fb.me/JSXTransformer-0.13.3.js"></script>
 	<script src="http://code.jquery.com/jquery-1.10.0.min.js"></script>
 	<script src="http://cdnjs.cloudflare.com/ajax/libs/showdown/0.3.1/showdown.min.js"></script>
 	<script src="http://cdnjs.cloudflare.com/ajax/libs/es5-shim/2.2.0/es5-shim.min.js"></script>

--- a/client/js/gallery.js
+++ b/client/js/gallery.js
@@ -153,7 +153,8 @@
 	});
 
 
-	React.renderComponent(
+	//React.renderComponent(
+	React.render(
 	  <GalleryWithControls />,
 	  document.getElementById('gallery')
 	);


### PR DESCRIPTION
Hi,
I received several HTTP 500 errors while testing the client: ReactJS 0.8 seems to no longer be available, so I have corrected the URLs to use the latest (0.13.3) release, and also made a quick fix to the rendering line of code at the end of client.js that was needed to use the newer release of the library.
